### PR TITLE
Fix documentation retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Retireve the code by cloning the repository
 
 ```bash
 # Clone and choose the repo
-git clone https://github.com/ellingsvee/JutulGPT.git
+git clone https://github.com/SINTEF-agentlab/JutulGPT.git
 cd JutulGPT/
 ```
 
@@ -251,10 +251,6 @@ pnpm dev # Run from JutulGPT-GUI/ directory
 The GUI can now be accessed on `http://localhost:3000/` (or some other location depending on your JutulGPT-GUI configuration).
 
 > NOTE: Remember to set `cli = false` under `[mode]` in `jutulgpt.toml`.
-
-## Fimbul (WARNING)
-
-There is some legacy code for generating code for the Fimbul package. I have removed a lot of it, but it can be re-implemented by adding some tools and modifying the prompts. My suggestion is to get familiar with the current tools fot JutulDarcy, and then later extend to Fimbul.
 
 ## Testing
 

--- a/jutulgpt.toml
+++ b/jutulgpt.toml
@@ -24,7 +24,7 @@ show_reasoning_summary = true
 # provider: "bm25", "faiss", or "chroma"
 # search_type: "similarity", "mmr", or "similarity_score_threshold"
 [retrieval]
-provider = "bm25"
+provider = "chroma"
 search_type = "mmr" # only applicable for some providers
 
 [retrieval.search_kwargs]

--- a/jutulgpt.toml
+++ b/jutulgpt.toml
@@ -28,7 +28,7 @@ provider = "chroma"
 search_type = "mmr" # only applicable for some providers
 
 [retrieval.search_kwargs]
-k = 2
+k = 3
 fetch_k = 10
 lambda_mult = 0.5
 

--- a/src/jutulgpt/cli/cli_utils.py
+++ b/src/jutulgpt/cli/cli_utils.py
@@ -265,17 +265,6 @@ def stream_to_console(
         content = Markdown(streamed_text) if with_markdown else streamed_text
         console.print(Panel.fit(content, **panel_kwargs))
 
-    # Tool calls (when agent makes tool calls without text output)
-    if has_tools and not has_text and ai_message:
-        names = [tc.get("name", "?") for tc in getattr(ai_message, "tool_calls", [])]
-        console.print(
-            Panel(
-                Text(f"Calling tools: {', '.join(names)}", style="dim"),
-                title=title or "Agent",
-                border_style="dim cyan",
-            )
-        )
-
     if ai_message is None:
         raise RuntimeError("No message from model")
     return ai_message

--- a/src/jutulgpt/human_in_the_loop/cli.py
+++ b/src/jutulgpt/human_in_the_loop/cli.py
@@ -283,7 +283,7 @@ def modify_rag_query(query: str, retriever_name: str) -> str:
 
     Args:
         query: The original query string
-        retriever_name: Name of the retriever (e.g., "JutulDarcy", "Fimbul")
+        retriever_name: Name of the retriever (e.g., "JutulDarcy")
 
     Returns:
         str: The potentially modified query (empty string if skipped)

--- a/src/jutulgpt/human_in_the_loop/ui.py
+++ b/src/jutulgpt/human_in_the_loop/ui.py
@@ -176,7 +176,7 @@ def modify_rag_query(query: str, retriever_name: str) -> str:
 
     Args:
         query: The original query string
-        retriever_name: Name of the retriever (e.g., "JutulDarcy", "Fimbul")
+        retriever_name: Name of the retriever (e.g., "JutulDarcy")
 
     Returns:
         str: The potentially modified query (empty string if skipped)

--- a/src/jutulgpt/julia/julia_code_runner.py
+++ b/src/jutulgpt/julia/julia_code_runner.py
@@ -47,7 +47,12 @@ def run_julia_file(code: str, julia_file_name: str, project_dir: str | None = No
             pass  # File might already be deleted
 
 
-def run_code_string_direct(code: str, project_dir: str | None = None):
+def run_code_string_direct(
+    code: str,
+    project_dir: str | None = None,
+    startup_file: bool = True,
+    history_file: bool = True,
+):
     """
     Alternative approach: Run Julia code directly using -e flag instead of temporary file.
     """
@@ -55,8 +60,15 @@ def run_code_string_direct(code: str, project_dir: str | None = None):
         project_dir = os.getcwd()
 
     try:
+        cmd = ["julia", f"--project={project_dir}"]
+        if not startup_file:
+            cmd.append("--startup-file=no")
+        if not history_file:
+            cmd.append("--history-file=no")
+        cmd.extend(["-e", code])
+
         result = subprocess.run(
-            ["julia", f"--project={project_dir}", "-e", code],
+            cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/src/jutulgpt/nodes/check_code.py
+++ b/src/jutulgpt/nodes/check_code.py
@@ -14,7 +14,7 @@ from jutulgpt.julia import get_error_message, get_linting_result, run_code
 from jutulgpt.logging import CodeRunnerEntry, ToolEntry, get_session_logger
 from jutulgpt.state import State
 from jutulgpt.utils.code_parsing import add_julia_context, get_code_from_response
-from jutulgpt.utils.code_transforms import fix_imports, shorter_simulations
+from jutulgpt.utils.code_transforms import shorter_simulations
 
 
 def _truncate(text: str, max_length: int = DISPLAY_CONTENT_MAX_LENGTH) -> str:
@@ -207,9 +207,6 @@ def check_code(
             + add_julia_context(code)
         )
         messages_list.append(HumanMessage(content=code_update_message))
-
-    # Hangle the importing of the Fimbul and GLMakie package
-    code = fix_imports(code)
 
     # Then shorten the code for faster simulations
     # code = shorter_simulations(code)

--- a/src/jutulgpt/prompts.py
+++ b/src/jutulgpt/prompts.py
@@ -65,7 +65,7 @@ Be proactive and thorough with tool usage:
 - **Wrapping**: Wrap your code in a block ```julia your code here ```. Do not include `\n` or other non-unary operators to your outputted code.
 - **Standard library preference**: Avoid external packages unless explicitly required
 - **Proper syntax**: Remember `end` statements, proper indexing, etc.
-- **Import dependencies**: Always import Jutul when using JutulDarcy/Fimbul
+- **Import dependencies**: Always import Jutul when using JutulDarcy
 
 ---
 
@@ -159,7 +159,7 @@ Be proactive and thorough with tool usage:
 - **Wrapping**: Wrap your code in a block ```julia your code here ```. Do not include `\n` or other non-unary operators to your outputted code.
 - **Standard library preference**: Avoid external packages unless explicitly required
 - **Proper syntax**: Remember `end` statements, proper indexing, etc.
-- **Import dependencies**: Always import Jutul when using JutulDarcy/Fimbul
+- **Import dependencies**: Always import Jutul when using JutulDarcy
 
 ---
 

--- a/src/jutulgpt/rag/package_paths.py
+++ b/src/jutulgpt/rag/package_paths.py
@@ -68,6 +68,21 @@ def get_package_docs_path(package_name: str, subdirs: list[str] | None = None) -
     raise FileNotFoundError(f"{package_name} documentation not found. Tried: {tried}")
 
 
+def get_package_faq_path(package_name: str, subpaths: list[str] | None = None) -> str:
+    """Return the FAQ markdown file path for a Julia package."""
+    if subpaths is None:
+        subpaths = ["docs/src/extras/faq.md"]
+
+    root = get_package_root(package_name)
+    for subpath in subpaths:
+        candidate = root / subpath
+        if candidate.exists() and candidate.is_file():
+            return str(candidate)
+
+    tried = ", ".join(str(root / s) for s in subpaths)
+    raise FileNotFoundError(f"{package_name} FAQ not found. Tried: {tried}")
+
+
 def get_package_examples_path(package_name: str, subdir: str = "examples") -> str:
     """Return the examples directory for a Julia package."""
     root = get_package_root(package_name)

--- a/src/jutulgpt/rag/retriever_specs.py
+++ b/src/jutulgpt/rag/retriever_specs.py
@@ -6,6 +6,7 @@ always stay in sync with the version the user has installed.
 
 from dataclasses import dataclass
 from functools import lru_cache, partial
+import hashlib
 from typing import Callable, Optional, Union
 
 from jutulgpt.rag import split_docs, split_examples
@@ -20,6 +21,27 @@ class RetrieverSpec:
     persist_path: Optional[Callable] = None
     cache_path: Optional[str] = None
     collection_name: Optional[str] = None
+
+
+def _persist_path(name: str, provider: str, suffix: str) -> str:
+    from jutulgpt.configuration import PROJECT_ROOT
+
+    return str(
+        PROJECT_ROOT
+        / "rag"
+        / "retriever_store"
+        / f"retriever_{name}_{provider}_{suffix}"
+    )
+
+
+def _cache_path(name: str, suffix: str) -> str:
+    from jutulgpt.configuration import PROJECT_ROOT
+
+    return str(PROJECT_ROOT / "rag" / "loaded_store" / f"loaded_{name}_{suffix}.pkl")
+
+
+def _suffix_from_path(path: str) -> str:
+    return hashlib.sha1(path.encode("utf-8")).hexdigest()[:12]
 
 
 @lru_cache(maxsize=None)
@@ -46,13 +68,21 @@ def _get_jutuldarcy_spec(doc_type: str) -> RetrieverSpec:
     from jutulgpt.rag.package_paths import (
         get_package_docs_path,
         get_package_examples_path,
+        get_package_root,
     )
+
+    package_suffix = _suffix_from_path(str(get_package_root("JutulDarcy")))
 
     if doc_type == "docs":
         return RetrieverSpec(
             dir_path=get_package_docs_path("JutulDarcy"),
             filetype="md",
             split_func=split_docs.split_docs,
+            persist_path=lambda provider: _persist_path(
+                "jutuldarcy_docs", provider, package_suffix
+            ),
+            cache_path=_cache_path("jutuldarcy_docs", package_suffix),
+            collection_name=f"jutuldarcy_docs_{package_suffix}",
         )
     elif doc_type == "examples":
         return RetrieverSpec(
@@ -62,6 +92,11 @@ def _get_jutuldarcy_spec(doc_type: str) -> RetrieverSpec:
                 split_examples.split_examples,
                 header_to_split_on=1,  # Split on `# #`
             ),
+            persist_path=lambda provider: _persist_path(
+                "jutuldarcy_examples", provider, package_suffix
+            ),
+            cache_path=_cache_path("jutuldarcy_examples", package_suffix),
+            collection_name=f"jutuldarcy_examples_{package_suffix}",
         )
     raise ValueError(f"Unknown doc_type for jutuldarcy: {doc_type}")
 
@@ -79,6 +114,11 @@ def _get_fimbul_spec(doc_type: str) -> RetrieverSpec:
             dir_path=str(PROJECT_ROOT / "rag" / "fimbul" / "docs" / "man"),
             filetype="md",
             split_func=split_docs.split_docs,
+            persist_path=lambda provider: _persist_path(
+                "fimbul_docs", provider, "local"
+            ),
+            cache_path=_cache_path("fimbul_docs", "local"),
+            collection_name="fimbul_docs_local",
         )
     elif doc_type == "examples":
         return RetrieverSpec(
@@ -88,5 +128,10 @@ def _get_fimbul_spec(doc_type: str) -> RetrieverSpec:
                 split_examples.split_examples,
                 header_to_split_on=1,  # Split on `# #`
             ),
+            persist_path=lambda provider: _persist_path(
+                "fimbul_examples", provider, "local"
+            ),
+            cache_path=_cache_path("fimbul_examples", "local"),
+            collection_name="fimbul_examples_local",
         )
     raise ValueError(f"Unknown doc_type for fimbul: {doc_type}")

--- a/src/jutulgpt/rag/retriever_specs.py
+++ b/src/jutulgpt/rag/retriever_specs.py
@@ -54,8 +54,6 @@ def get_retriever_spec(package: str, doc_type: str) -> RetrieverSpec:
     """
     if package == "jutuldarcy":
         return _get_jutuldarcy_spec(doc_type)
-    elif package == "fimbul":
-        return _get_fimbul_spec(doc_type)
     raise ValueError(f"Unknown package: {package}")
 
 
@@ -99,39 +97,3 @@ def _get_jutuldarcy_spec(doc_type: str) -> RetrieverSpec:
             collection_name=f"jutuldarcy_examples_{package_suffix}",
         )
     raise ValueError(f"Unknown doc_type for jutuldarcy: {doc_type}")
-
-
-# ---------------------------------------------------------------------------
-# Fimbul – still uses local rag/ copies
-# ---------------------------------------------------------------------------
-
-
-def _get_fimbul_spec(doc_type: str) -> RetrieverSpec:
-    from jutulgpt.configuration import PROJECT_ROOT
-
-    if doc_type == "docs":
-        return RetrieverSpec(
-            dir_path=str(PROJECT_ROOT / "rag" / "fimbul" / "docs" / "man"),
-            filetype="md",
-            split_func=split_docs.split_docs,
-            persist_path=lambda provider: _persist_path(
-                "fimbul_docs", provider, "local"
-            ),
-            cache_path=_cache_path("fimbul_docs", "local"),
-            collection_name="fimbul_docs_local",
-        )
-    elif doc_type == "examples":
-        return RetrieverSpec(
-            dir_path=str(PROJECT_ROOT / "rag" / "fimbul" / "examples"),
-            filetype="jl",
-            split_func=partial(
-                split_examples.split_examples,
-                header_to_split_on=1,  # Split on `# #`
-            ),
-            persist_path=lambda provider: _persist_path(
-                "fimbul_examples", provider, "local"
-            ),
-            cache_path=_cache_path("fimbul_examples", "local"),
-            collection_name="fimbul_examples_local",
-        )
-    raise ValueError(f"Unknown doc_type for fimbul: {doc_type}")

--- a/src/jutulgpt/tools/execution.py
+++ b/src/jutulgpt/tools/execution.py
@@ -69,7 +69,7 @@ class RunJuliaCodeInput(BaseModel):
 )
 def run_julia_code(code: str):
     code = fix_imports(code)
-    code = shorter_simulations(code)
+    #code = shorter_simulations(code)
     out, code_failed = _run_julia_code(code, print_code=True)
     if code_failed:
         return out

--- a/src/jutulgpt/tools/execution.py
+++ b/src/jutulgpt/tools/execution.py
@@ -12,7 +12,7 @@ from jutulgpt.cli import colorscheme, print_to_console
 from jutulgpt.configuration import OUTPUT_TRUNCATION_LIMIT
 from jutulgpt.logging import ToolEntry, get_session_logger
 from jutulgpt.nodes.check_code import _run_julia_code, _run_linter
-from jutulgpt.utils.code_transforms import fix_imports, shorter_simulations
+from jutulgpt.utils.code_transforms import shorter_simulations
 
 
 def _truncate_output(
@@ -68,7 +68,6 @@ class RunJuliaCodeInput(BaseModel):
     description="Execute Julia code. Returns output or error message.",
 )
 def run_julia_code(code: str):
-    code = fix_imports(code)
     #code = shorter_simulations(code)
     out, code_failed = _run_julia_code(code, print_code=True)
     if code_failed:

--- a/src/jutulgpt/tools/retrieve.py
+++ b/src/jutulgpt/tools/retrieve.py
@@ -72,8 +72,16 @@ def make_retrieve_tool(
         if retrieved_examples:
             sources = [get_file_source(doc) for doc in retrieved_examples]
             unique_sources = list(dict.fromkeys(sources))  # Deduplicate while preserving order
+
+            # Make paths relative to package root for cleaner display
+            package_root = str(get_package_root(doc_label))
+            relative_sources = [
+                s.replace(package_root + "/", "") if s.startswith(package_root) else s
+                for s in unique_sources
+            ]
+
             summary = f"Retrieved {len(retrieved_examples)} examples:\n" + "\n".join(
-                f"- {s}" for s in unique_sources
+                f"- {s}" for s in relative_sources
             )
         else:
             summary = "No examples found"

--- a/src/jutulgpt/tools/retrieve.py
+++ b/src/jutulgpt/tools/retrieve.py
@@ -141,13 +141,6 @@ class RetrieveJutulDarcyInput(BaseModel):
         "The query that will be used for document and example retrieval",
     )
 
-
-class RetrieveFimbulInput(BaseModel):
-    query: str = Field(
-        "The query that will be used for document and example retrieval",
-    )
-
-
 # Create tools
 retrieve_jutuldarcy_examples = make_retrieve_tool(
     name="retrieve_jutuldarcy_examples",
@@ -155,14 +148,6 @@ retrieve_jutuldarcy_examples = make_retrieve_tool(
     doc_label="JutulDarcy",
     input_cls=RetrieveJutulDarcyInput,
 )
-
-retrieve_fimbul = make_retrieve_tool(
-    name="retrieve_fimbul",
-    doc_key="fimbul",
-    doc_label="Fimbul",
-    input_cls=RetrieveFimbulInput,
-)
-
 
 class RetrieveFunctionDocumentationInput(BaseModel):
     function_names: List[str] = Field(

--- a/src/jutulgpt/tools/retrieve.py
+++ b/src/jutulgpt/tools/retrieve.py
@@ -190,7 +190,11 @@ class GrepSearchInput(BaseModel):
     """Input for grep search tool."""
 
     query: str = Field(
-        description="The keyword based pattern to search for in files. Can be a regex or plain text pattern"
+        description=(
+            "The search pattern. With isRegexp=false (default), searches for the exact phrase. "
+            "With isRegexp=true, supports regex patterns (e.g. 'CartesianMesh|setup_well' for OR). "
+            "For multiple unrelated terms, prefer separate searches."
+        )
     )
     includePattern: Optional[str] = Field(
         default=None,
@@ -203,7 +207,11 @@ class GrepSearchInput(BaseModel):
         ),
     )
     isRegexp: Optional[bool] = Field(
-        default=False, description="Whether the pattern is a regex."
+        default=False,
+        description=(
+            "If false (default), query is treated as exact phrase/substring. "
+            "If true, query is a regex pattern supporting OR (|), wildcards, etc."
+        ),
     )
 
 

--- a/src/jutulgpt/utils/__init__.py
+++ b/src/jutulgpt/utils/__init__.py
@@ -18,7 +18,6 @@ from jutulgpt.utils.code_parsing import (
 )
 from jutulgpt.utils.code_transforms import (
     check_for_package_install,
-    fix_imports,
     remove_plotting,
     replace_case,
     shorten_first_argument,
@@ -48,7 +47,6 @@ __all__ = [
     "split_code_into_lines",
     # code_transforms
     "check_for_package_install",
-    "fix_imports",
     "remove_plotting",
     "replace_case",
     "shorten_first_argument",

--- a/src/jutulgpt/utils/code_transforms.py
+++ b/src/jutulgpt/utils/code_transforms.py
@@ -145,10 +145,3 @@ def shorter_simulations(code: str) -> str:
         )
 
     return code
-
-
-def fix_imports(code: str) -> str:
-    required_imports = ["Fimbul", "GLMakie"]
-    if not all(pkg in code for pkg in required_imports):
-        return code
-    return 'using Pkg; Pkg.activate(".");\n' + code


### PR DESCRIPTION
This PR contains several fixes and improvements for the documentation retrieval.

- It sets the default back to chroma vector store again. The recently introduced BM25 option is interesting as an fast alternative. But from my tests I got better results when using the original vector store. I think we need more tests before we consider changing the default here.
- It sets up the persistant paths for the vector store to function.
- Improves the grep search
- Removes all references to fimbul, since this support was incomplete and there were elements of the prompts that mentioned fimbul even though we do not fully support it. I therefore removed it until we want to potentially add full support here again.