### PR TITLE
Add prompt from file and log fix

### DIFF
--- a/src/jutulgpt/cli/cli_args.py
+++ b/src/jutulgpt/cli/cli_args.py
@@ -17,6 +17,8 @@ from jutulgpt import configuration as cfg
 class CliArgs:
     model: str
     skip_terminal_approval: bool
+    prompt: Optional[str] = None
+    prompt_file: Optional[str] = None
 
 
 def _normalize_model_name(name: str) -> str:
@@ -64,8 +66,25 @@ def parse_cli_args(argv: Optional[list[str]] = None) -> CliArgs:
             "Enables fully autonomous operation."
         ),
     )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        metavar="TEXT",
+        help="Initial user prompt text",
+    )
+    parser.add_argument(
+        "--prompt-file",
+        default=None,
+        metavar="PATH",
+        help="Read initial prompt from file PATH",
+    )
     ns = parser.parse_args(argv)
-    return CliArgs(model=ns.model, skip_terminal_approval=ns.skip_terminal_approval)
+    return CliArgs(
+        model=ns.model,
+        skip_terminal_approval=ns.skip_terminal_approval,
+        prompt=ns.prompt,
+        prompt_file=ns.prompt_file,
+    )
 
 
 def apply_model_from_cli(model: str) -> None:

--- a/src/jutulgpt/nodes/check_code.py
+++ b/src/jutulgpt/nodes/check_code.py
@@ -84,7 +84,7 @@ def _run_julia_code(code: str, print_code: bool = True) -> tuple[str, bool]:
     logger = get_session_logger()
 
     if print_code:
-        display_code = _truncate(f"```julia\n{code}\n```")
+        display_code = f"```julia\n{code}\n```"
         print_to_console(
             text="Running code:\n" + display_code,
             title="Code Runner",
@@ -95,6 +95,18 @@ def _run_julia_code(code: str, print_code: bool = True) -> tuple[str, bool]:
             text="Running code...",
             title="Code Runner",
             border_style=colorscheme.warning,
+        )
+
+    # Log full code before execution
+    if logger:
+        logger.log(
+            CodeRunnerEntry(
+                content="",
+                title="Code Runner",
+                code=code,
+                language="julia",
+                success=None,
+            )
         )
 
     # result = run_string(code)
@@ -123,7 +135,7 @@ def _run_julia_code(code: str, print_code: bool = True) -> tuple[str, bool]:
                 CodeRunnerEntry(
                     content=f"Code failed!\n\n{display_error}{truncation_note}",
                     title="Code Runner",
-                    code=code,
+                    code=None,
                     language="julia",
                     success=False,
                 )
@@ -173,7 +185,7 @@ def _run_julia_code(code: str, print_code: bool = True) -> tuple[str, bool]:
             CodeRunnerEntry(
                 content=log_message,
                 title="Code Runner",
-                code=code,
+                code=None,
                 language="julia",
                 success=True,
             )


### PR DESCRIPTION
This PR adds support for two new ways of inputting the initial prompt:

`python examples/autonomous_agent.py --prompt "Please set up..."`  and  `python examples/autonomous_agent.py --prompt-file prompt.txt`

This is useful if you have very long prompts, want to run the agent from a script, or running the same prompt several times. 

It also adds a small fix to make sure we don't truncate the code that is being run for the terminal display. In addition to logging the full code to the log before execution.